### PR TITLE
FEATURE: CacheControl, ETag and If-None-Match header support

### DIFF
--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -1,0 +1,103 @@
+<?php
+namespace Flowpack\FullPageCache\Http;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Component\ComponentInterface;
+use Flowpack\FullPageCache\Cache\MetadataAwareStringFrontend;
+use Flowpack\FullPageCache\Aspects\ContentCacheAspect;
+
+/**
+ * Cache control header component
+ */
+class CacheControlHeaderComponent implements ComponentInterface
+{
+    /**
+     * @Flow\Inject
+     * @var MetadataAwareStringFrontend
+     */
+    protected $contentCache;
+
+
+    /**
+     * @var boolean
+     * @Flow\InjectConfiguration(path="enabled")
+     */
+    protected $enabled;
+
+    /**
+     * @Flow\Inject
+     * @var ContentCacheAspect
+     */
+    protected $contentCacheAspect;
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(ComponentContext $componentContext)
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $request = $componentContext->getHttpRequest();
+        if (strtoupper($request->getMethod()) !== 'GET') {
+            return;
+        }
+
+        if (!empty($request->getUri()->getQuery())) {
+            return;
+        }
+
+        $response = $componentContext->getHttpResponse();
+
+        if ($response->hasHeader('X-From-FullPageCache')) {
+            return;
+        }
+
+        if ($this->contentCacheAspect->hasUncachedSegments())
+        {
+            return;
+        }
+
+        if ($response->hasHeader('Set-Cookie')) {
+            return;
+        }
+
+        [$tags, $lifetime] = $this->getCacheTagsAndLifetime();
+
+        if ($tags) {
+            $modifiedResponse = $response
+                ->withHeader('CacheControl', 's-maxage=' . ($lifetime ?? 86400))
+                ->withHeader('X-CacheTags', $tags);
+
+            $componentContext->replaceHttpResponse($modifiedResponse);
+        }
+    }
+
+    /**
+     * Get cache tags and lifetime from the cache metadata that was extracted by the special cache frontend for content cache
+     *
+     * @return array with first "tags" and then "lifetime"
+     */
+    protected function getCacheTagsAndLifetime(): array
+    {
+        $lifetime = null;
+        $tags = [];
+        $entriesMetadata = $this->contentCache->getAllMetadata();
+        foreach ($entriesMetadata as $identifier => $metadata) {
+            $entryTags = isset($metadata['tags']) ? $metadata['tags'] : [];
+            $entryLifetime = isset($metadata['lifetime']) ? $metadata['lifetime'] : null;
+            if ($entryLifetime !== null) {
+                if ($lifetime === null) {
+                    $lifetime = $entryLifetime;
+                } else {
+                    $lifetime = min($lifetime, $entryLifetime);
+                }
+            }
+            $tags = array_unique(array_merge($tags, $entryTags));
+        }
+
+        return [$tags, $lifetime];
+    }
+}

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -68,7 +68,7 @@ class CacheControlHeaderComponent implements ComponentInterface
 
         if ($tags) {
             $modifiedResponse = $response
-                ->withHeader('CacheControl', 's-maxage=' . ($lifetime ?? 86400))
+                ->withHeader('X-CacheLifetime', $lifetime)
                 ->withHeader('X-CacheTags', $tags);
 
             $componentContext->replaceHttpResponse($modifiedResponse);

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flowpack\FullPageCache\Http;
 
+use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Http\Component\ComponentChain;
@@ -65,8 +66,31 @@ class RequestInterceptorComponent implements ComponentInterface
 
         $entry = $this->cacheFrontend->get($entryIdentifier);
         if ($entry) {
-            $response = parse_response($entry);
-            $response = $response->withHeader('X-From-FullPageCache', $entryIdentifier);
+            $cachedResponse = parse_response($entry);
+
+            $etag = $cachedResponse->getHeaderLine('ETag');
+            $lifetime = (int)$cachedResponse->getHeaderLine('X-Storage-Lifetime');
+            $timestamp = (int)$cachedResponse->getHeaderLine('X-Storage-Timestamp');
+            $age = time() - $timestamp;
+
+            if ($age > $lifetime) {
+                return;
+            }
+
+            $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+            if ($ifNoneMatch &&  $ifNoneMatch === $etag ) {
+                $response = (new Response( 304))
+                    ->withHeader('CacheControl', 'max-age=' . ($lifetime - $age))
+                    ->withHeader('X-From-FullPageCache', $entryIdentifier);
+            } else {
+                $response = $cachedResponse
+                    ->withoutHeader('X-Storage-Lifetime')
+                    ->withoutHeader('X-Storage-Timestamp')
+                    ->withoutHeader('CacheControl')
+                    ->withHeader('CacheControl', 'max-age=' . ($lifetime - $age))
+                    ->withHeader('X-From-FullPageCache', $entryIdentifier);
+            }
+
             $componentContext->replaceHttpResponse($response);
             $componentContext->setParameter(ComponentChain::class, 'cancel', true);
         }

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,13 @@
+Flowpack\FullPageCache\Http\CacheControlHeaderComponent:
+  properties:
+    contentCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Neos_Fusion_Content
+
 Flowpack\FullPageCache\Http\RequestInterceptorComponent:
   properties:
     cacheFrontend:
@@ -17,13 +27,6 @@ Flowpack\FullPageCache\Http\RequestStorageComponent:
         arguments:
           1:
             value: Flowpack_FullPageCache_Entries
-    contentCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Neos_Fusion_Content
 
 Flowpack\FullPageCache\Aspects\ContentCacheAspect:
   properties:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,6 +10,9 @@ Neos:
             requestInterceptor:
               position: 'start 999999'
               component: 'Flowpack\FullPageCache\Http\RequestInterceptorComponent'
+            addCacheHeader:
+              position: 'after setHeader'
+              component: 'Flowpack\FullPageCache\Http\CacheControlHeaderComponent'
         'postprocess':
           chain:
             requestStorage:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,11 @@
 Flowpack:
   FullPageCache:
+    # enable full page caching
     enabled: true
+
+    # the maximum public cache control header sent
+    # set to 0 if you do not want to send public CacheControl headers
+    maxPublicCacheTime: 86400
 Neos:
   Flow:
     http:


### PR DESCRIPTION
- The detection of the cache status is moved to into a separate component, the headers X-CacheTags and X-CacheLifetime are used by the http caching component.
- An ETag is calculated from the md5 of the response body when caching is allowed
- A Status 304 "not modified" is sent for requests wehere if-none-match equals the ETag
- The results get a public CacheControl with a max-age heaeder with a maximum value defined via settings. That way browser caches will pick up freshly re rendered documents as fast as possible.