### PR TITLE
BUGFIX: Prevent error with single cache tag

### DIFF
--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -51,6 +51,10 @@ class RequestStorageComponent implements ComponentInterface
             $cacheTags = $response->getHeader('X-CacheTags') ;
             $entryIdentifier = md5((string)$request->getUri());
 
+            if (!is_array($cacheTags)) {
+                $cacheTags = [$cacheTags];
+            }
+
             $publicLifetime = 0;
             if ($this->maxPublicCacheTime > 0) {
                 if ($lifetime > 0 && $lifetime < $this->maxPublicCacheTime) {


### PR DESCRIPTION
When only a single cache tag is defined the type
of `$cacheTags` is not an array and only holds a single
cache tag as string which causes an exception when setting the cache entry.

The original problem seems to be a wrong return type
by `getHeader` as the docs says it should always return
an array. This might need to be investigated if it's not
already fixed in recent Flow versions.

Affects: Neos 4.3