### PR TITLE
BUGFIX: Improve ETag handling, HEAD support and x-cache headers in results

### DIFF
--- a/Classes/Aspects/ContentCacheAspect.php
+++ b/Classes/Aspects/ContentCacheAspect.php
@@ -28,7 +28,7 @@ class ContentCacheAspect
     protected $cacheFrontend;
 
     /**
-     * @Flow\Before("method(Neos\Fusion\Core\Cache\ContentCache->createUncachedSegment())")
+     * @Flow\Before("method(Neos\Fusion\Core\Cache\ContentCache->(createUncachedSegment|replaceUncachedPlaceholders)())")
      */
     public function grabUncachedSegment(JoinPointInterface $joinPoint)
     {

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -41,7 +41,7 @@ class CacheControlHeaderComponent implements ComponentInterface
         }
 
         $request = $componentContext->getHttpRequest();
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!in_array(strtoupper($request->getMethod()), ['GET', 'HEAD'])) {
             return;
         }
 

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -84,7 +84,7 @@ class RequestInterceptorComponent implements ComponentInterface
 
             // return 304 not modified when possible
             $ifNoneMatch = $request->getHeaderLine('If-None-Match');
-            if ($ifNoneMatch && $ifNoneMatch === $etag ) {
+            if ($ifNoneMatch && ($ifNoneMatch === $etag || $ifNoneMatch === 'W/' . $etag)) {
                 if (class_exists('Neos\\Flow\\Http\\Response')) {
                     $notModifiedResponse = new \Neos\Flow\Http\Response();
                 } else {

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -56,7 +56,7 @@ class RequestInterceptorComponent implements ComponentInterface
         }
 
         $request = $componentContext->getHttpRequest();
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!in_array(strtoupper($request->getMethod()), ['GET', 'HEAD'])) {
             return;
         }
 

--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -77,7 +77,7 @@ class RequestStorageComponent implements ComponentInterface
             if ($publicLifetime > 0) {
                 $entryContentHash = md5(str($response));
                 $modifiedResponse = $modifiedResponse
-                    ->withAddedHeader('ETag', $entryContentHash)
+                    ->withAddedHeader('ETag', '"' . $entryContentHash . '"')
                     ->withAddedHeader('CacheControl', 'max-age=' . $publicLifetime);
             }
 

--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -41,8 +41,14 @@ class RequestStorageComponent implements ComponentInterface
         if ($response->hasHeader('X-From-FullPageCache')) {
             return;
         }
-        
+
         if ($response->hasHeader('Set-Cookie')) {
+            if ($response->hasHeader('X-CacheLifetime')) {
+                $responseWithoutStorageHeaders = $response
+                    ->withoutHeader('X-CacheTags')
+                    ->withoutHeader('X-CacheLifetime');
+                $componentContext->replaceHttpResponse($responseWithoutStorageHeaders);
+            }
             return;
         }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -21,5 +21,5 @@ Neos:
         'postprocess':
           chain:
             requestStorage:
-              position: 'after standardsCompliance'
+              position: 'before standardsCompliance'
               component: 'Flowpack\FullPageCache\Http\RequestStorageComponent'


### PR DESCRIPTION
The generated ETags now are wrapped in quotes as is required by standard compliant and work together with Nginx gzipping the content. Also weak etags are now accepted which are created by proxies that encode the request and 304 responses now get the headers of the original response.

Head requests now will also contain the ETags and a HEAD request before  a GET will prefill the 
full page cache and will avoid rendering the page twice. This required to move the requestStoreage
before the standardsCompliance component.

In some conditions the internal x-cache headers were not removed before and also uncached segments were not detected when beeing replaced in a bigger cache-fragment. This lead to unjustified cache-control headers beeing sent and x-cache headers be exposed publicly.