### PR TITLE
TASK: Improve304 handling for neos52

### DIFF
--- a/Classes/Aspects/ContentCacheAspect.php
+++ b/Classes/Aspects/ContentCacheAspect.php
@@ -28,7 +28,7 @@ class ContentCacheAspect
     protected $cacheFrontend;
 
     /**
-     * @Flow\Before("method(Neos\Fusion\Core\Cache\ContentCache->createUncachedSegment())")
+     * @Flow\Before("method(Neos\Fusion\Core\Cache\ContentCache->(createUncachedSegment|replaceUncachedPlaceholders)())")
      */
     public function grabUncachedSegment(JoinPointInterface $joinPoint)
     {

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -41,7 +41,7 @@ class CacheControlHeaderComponent implements ComponentInterface
         }
 
         $request = $componentContext->getHttpRequest();
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!in_array(strtoupper($request->getMethod()), ['GET', 'HEAD'])) {
             return;
         }
 

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -84,7 +84,7 @@ class RequestInterceptorComponent implements ComponentInterface
 
             // return 304 not modified when possible
             $ifNoneMatch = $request->getHeaderLine('If-None-Match');
-            if ($ifNoneMatch && $ifNoneMatch === $etag ) {
+            if ($ifNoneMatch && ($ifNoneMatch === $etag || $ifNoneMatch === 'W/' . $etag)) {
                 if (class_exists('Neos\\Flow\\Http\\Response')) {
                     $notModifiedResponse = new \Neos\Flow\Http\Response();
                 } else {

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -77,7 +77,6 @@ class RequestInterceptorComponent implements ComponentInterface
                 $cachedResponse = parse_response($entry);
             }
 
-            $etag = $cachedResponse->getHeaderLine('ETag');
             $lifetime = (int)$cachedResponse->getHeaderLine('X-Storage-Lifetime');
             $timestamp = (int)$cachedResponse->getHeaderLine('X-Storage-Timestamp');
 
@@ -100,12 +99,6 @@ class RequestInterceptorComponent implements ComponentInterface
                     $cachedResponse = $cachedResponse
                         ->withHeader('CacheControl', 'max-age=' . $this->maxPublicCacheTime);
                 }
-            }
-
-            $ifNoneMatch = $request->getHeaderLine('If-None-Match');
-            if ($ifNoneMatch && ($ifNoneMatch === $etag || $ifNoneMatch === 'W/' . $etag)) {
-                $cachedResponse = $cachedResponse
-                    ->withStatus(304);
             }
 
             $componentContext->replaceHttpResponse($cachedResponse);

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -56,7 +56,7 @@ class RequestInterceptorComponent implements ComponentInterface
         }
 
         $request = $componentContext->getHttpRequest();
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!in_array(strtoupper($request->getMethod()), ['GET', 'HEAD'])) {
             return;
         }
 

--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -77,7 +77,7 @@ class RequestStorageComponent implements ComponentInterface
             if ($publicLifetime > 0) {
                 $entryContentHash = md5(str($response));
                 $modifiedResponse = $modifiedResponse
-                    ->withAddedHeader('ETag', $entryContentHash)
+                    ->withAddedHeader('ETag', '"' . $entryContentHash . '"')
                     ->withAddedHeader('CacheControl', 'max-age=' . $publicLifetime);
             }
 

--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -41,8 +41,14 @@ class RequestStorageComponent implements ComponentInterface
         if ($response->hasHeader('X-From-FullPageCache')) {
             return;
         }
-        
+
         if ($response->hasHeader('Set-Cookie')) {
+            if ($response->hasHeader('X-CacheLifetime')) {
+                $responseWithoutStorageHeaders = $response
+                    ->withoutHeader('X-CacheTags')
+                    ->withoutHeader('X-CacheLifetime');
+                $componentContext->replaceHttpResponse($responseWithoutStorageHeaders);
+            }
             return;
         }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -21,5 +21,5 @@ Neos:
         'postprocess':
           chain:
             requestStorage:
-              position: 'after standardsCompliance'
+              position: 'before standardsCompliance'
               component: 'Flowpack\FullPageCache\Http\RequestStorageComponent'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "name": "flowpack/fullpagecache",
     "license": "MIT",
     "require": {
-        "neos/neos": "~4.3.6 || ^5.0 || dev-master",
+        "neos/neos": "^5.2 || dev-master",
         "guzzlehttp/psr7": "^1.4"
     },
     "autoload": {


### PR DESCRIPTION
In Neos Versions > 5.2 the standard compliance component will create the 304 status if possible
so this code can be removed here.

Additionally the ETag is now created only from body content so headers like expires or data will not change the ETag.

This change is based on PR: #6