### PR TITLE
FEATURE: add optional query string parameter handling

### DIFF
--- a/Classes/Helper/CacheHelper.php
+++ b/Classes/Helper/CacheHelper.php
@@ -1,0 +1,56 @@
+<?php
+namespace Flowpack\FullPageCache\Helper;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Helper\UriHelper;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Helper functions for Flowpack.FullPageCache
+ */
+class CacheHelper
+{
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(path="queryArguments.include")
+     */
+    protected $includeQueryArguments;
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(path="queryArguments.ignore")
+     */
+    protected $ignoreQueryArguments;
+
+    /**
+     * @param UriInterface $uri
+     * @return string|null
+     */
+    public function getEntryIdentifier(UriInterface $uri)
+    {
+        if (empty($uri->getQuery()))
+            return md5((string)$uri);
+
+        // don't cache requests that include query strings if there is no query argument configuration
+        if (!empty($uri->getQuery()) && empty($this->includeQueryArguments) && empty($this->ignoreQueryArguments))
+            return null;
+
+        // process query arguments and decide if the request is cacheable
+        $queryArguments = UriHelper::parseQueryIntoArguments($uri);
+        $queryArgumentsWithoutIgnored = array_diff_key(
+            $queryArguments,
+            array_fill_keys($this->ignoreQueryArguments, true)
+        );
+        $queryArgumentsWithoutIgnoredAndWithoutIncluded = array_diff_key(
+            $queryArgumentsWithoutIgnored,
+            array_fill_keys($this->includeQueryArguments, true)
+        );
+
+        // not cacheable - if there are still arguments after filtering
+        if (!empty($queryArgumentsWithoutIgnoredAndWithoutIncluded))
+            return null;
+
+        // use uri without ignored query arguments
+        return md5((string)$uri->withQuery(http_build_query($queryArgumentsWithoutIgnored)));
+    }
+}

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flowpack\FullPageCache\Http;
 
+use Flowpack\FullPageCache\Helper\CacheHelper;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\ComponentInterface;
@@ -18,6 +19,11 @@ class CacheControlHeaderComponent implements ComponentInterface
      */
     protected $contentCache;
 
+    /**
+     * @Flow\Inject
+     * @var CacheHelper
+     */
+    protected $cacheHelper;
 
     /**
      * @var boolean
@@ -45,7 +51,7 @@ class CacheControlHeaderComponent implements ComponentInterface
             return;
         }
 
-        if (!empty($request->getUri()->getQuery())) {
+        if (is_null($this->cacheHelper->getEntryIdentifier($request->getUri()))) {
             return;
         }
 

--- a/Classes/Http/RequestInterceptorComponent.php
+++ b/Classes/Http/RequestInterceptorComponent.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flowpack\FullPageCache\Http;
 
+use Flowpack\FullPageCache\Helper\CacheHelper;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Http\Component\ComponentChain;
@@ -21,6 +22,12 @@ class RequestInterceptorComponent implements ComponentInterface
      * @var StringFrontend
      */
     protected $cacheFrontend;
+
+    /**
+     * @Flow\Inject
+     * @var CacheHelper
+     */
+    protected $cacheHelper;
 
     /**
      * @var boolean
@@ -60,15 +67,14 @@ class RequestInterceptorComponent implements ComponentInterface
             return;
         }
 
-        if (!empty($request->getUri()->getQuery())) {
+        $entryIdentifier = $this->cacheHelper->getEntryIdentifier($request->getUri());
+        if (is_null($entryIdentifier)) {
             return;
         }
 
         if ($this->sessionManager->getCurrentSession()->isStarted() && !empty($this->sessionDataContainer->getSecurityTokens())) {
             return;
         }
-
-        $entryIdentifier = md5((string)$request->getUri());
 
         $entry = $this->cacheFrontend->get($entryIdentifier);
         if ($entry) {

--- a/Classes/Http/RequestStorageComponent.php
+++ b/Classes/Http/RequestStorageComponent.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flowpack\FullPageCache\Http;
 
+use Flowpack\FullPageCache\Helper\CacheHelper;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentContext;
@@ -17,6 +18,12 @@ class RequestStorageComponent implements ComponentInterface
      * @var StringFrontend
      */
     protected $cacheFrontend;
+
+    /**
+     * @Flow\Inject
+     * @var CacheHelper
+     */
+    protected $cacheHelper;
 
     /**
      * @var boolean
@@ -41,7 +48,7 @@ class RequestStorageComponent implements ComponentInterface
         if ($response->hasHeader('X-From-FullPageCache')) {
             return;
         }
-        
+
         if ($response->hasHeader('Set-Cookie')) {
             return;
         }
@@ -49,7 +56,9 @@ class RequestStorageComponent implements ComponentInterface
         if ($response->hasHeader('X-CacheLifetime')) {
             $lifetime = (int)$response->getHeaderLine('X-CacheLifetime');
             $cacheTags = $response->getHeader('X-CacheTags') ;
-            $entryIdentifier = md5((string)$request->getUri());
+            $entryIdentifier = $this->cacheHelper->getEntryIdentifier($request->getUri());
+            if (is_null($entryIdentifier))
+                return;
 
             if (!is_array($cacheTags)) {
                 $cacheTags = [$cacheTags];

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,19 @@ Flowpack:
     # the maximum public cache control header sent
     # set to 0 if you do not want to send public CacheControl headers
     maxPublicCacheTime: 86400
+
+    # requests that include query arguments won't be cached by default to prevent unexpected caching behaviour
+    # however, if you know what you are doing, use these settings to enable cached results for query arguments
+    # if the request uri still has arguments that are not listed in 'include' or 'ignore', the default no-cache behaviour will apply
+    queryArguments:
+
+      # list of arguments that should response cached results
+      # thus we will *include* these arguments when we create and/or lookup the cache keys
+      include: []
+
+      # list of arguments that should be ignored (typically arguments that won't change the rendered html)
+      # thus we will *ignore* these arguments when we create and/or lookup the cache keys
+      ignore: []
 Neos:
   Flow:
     http:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@ Full Page Cache
 
 This package is meant to cache full HTTP responses for super fast delivery time. It currently works with Neos but a plan is there to provide the functionality for Flow as well.
 
-It works by checking if a page is fully cachable and in that case caching the  whole HTTP response and delivering it immediately. So this won't have much effect on  websites with uncached elements on every page. Also POST requests and requests with query arguments are excluded from caching, as well as requests that set cookies. So if you don't see a difference after installing, these are things to look out for.
+It works by checking if a page is fully cachable and in that case caching the whole HTTP response and delivering it immediately. So this won't have much effect on websites with uncached elements on every page. Also POST requests and requests with query arguments (unless you configured `queryArguments`) are excluded from caching, as well as requests that set cookies. So if you don't see a difference after installing, these are things to look out for.
 
 Settings
 --------
 
-Two settings are available to you to influence the behavior.
-
-```
+```yaml
 Flowpack:
   FullPageCache:
     # enable full page caching
@@ -19,6 +17,19 @@ Flowpack:
     # the maximum public cache control header sent
     # set to 0 if you do not want to send public CacheControl headers
     maxPublicCacheTime: 86400
+
+    # requests that include query arguments won't be cached by default to prevent unexpected caching behaviour
+    # however, if you know what you are doing, use these settings to enable cached results for query arguments
+    # if the request uri still has arguments that are not listed in 'include' or 'ignore', the default no-cache behaviour will apply
+    queryArguments:
+
+      # list of arguments that should response cached results
+      # thus we will *include* these arguments when we create and/or lookup the cache keys
+      include: []
+
+      # list of arguments that should be ignored (typically arguments that won't change the rendered html)
+      # thus we will *ignore* these arguments when we create and/or lookup the cache keys
+      ignore: []
 ```
 
 You can also move the cache backend to something faster if available, to improve performance even more.


### PR DESCRIPTION
This will enable an optional query string caching without changing the default behaviour.
#7 

**Example configuration**

```yaml
Flowpack:
  FullPageCache:
    queryArguments:
      include:
        - mode
      ignore:
        - utm_source
        - utm_medium
```

**Example requests**

* https://example.com => cached with key `md5(https://example.com)`
* https://example.com?mode=dark => cached with key `md5(https://example.com?mode=dark)`
* https://example.com?mode=dark&unknown_argument => uncached
* https://example.com?mode=light&utm_source=google => cached with key `md5(https://example.com?mode=light)`
* https://example.com?mode=light&utm_source=google&utm_medium=cpc => cached with key `md5(https://example.com?mode=light)`